### PR TITLE
Smooth off API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ $ venv/bin/pip install -e .
 $ venv/bin/py.test tests/
 ============================= test session starts ==============================
 platform linux -- Python 3.6.7, pytest-3.10.0, py-1.7.0, pluggy-0.8.0
-rootdir: /home/tseaver/projects/agendaless/Google/src/py-crc32c, inifile:
+rootdir: ..., inifile:
 collected 9 items                                                              
 
 tests/test___init__.py .........                                         [100%]

--- a/src/crc32c/__init__.py
+++ b/src/crc32c/__init__.py
@@ -35,7 +35,8 @@ def value(chunk):
     """Compute a CRC checksum for a chunk of data.
 
     Args
-        chunk (Union[bytes, List[int], Tuple[int]]) new chunk of data
+        chunk (Union[bytes, List[int], Tuple[int]]): A new chunk of data.
+            Intended to be a byte string or similar.
 
     Returns
         (int) New CRC computed from chunk.

--- a/src/crc32c/__init__.py
+++ b/src/crc32c/__init__.py
@@ -16,9 +16,26 @@ import crc32c.__config__
 import crc32c._crc32c_cffi
 
 
-def extend(*args, **kwargs):
-    return crc32c._crc32c_cffi.lib.crc32c_extend(*args, **kwargs)
+def extend(crc, chunk):
+    """Update an existing CRC with new chunk of data.
+
+    Args
+        crc: (int) existing CRC
+        chunk (Union[bytes, List[int], Tuple[int]]) new chunk of data
+
+    Returns
+        (int) New CRC computed by extending existing CRC with chunk.
+    """
+    return crc32c._crc32c_cffi.lib.crc32c_extend(crc, chunk, len(chunk))
 
 
-def value(*args, **kwargs):
-    return crc32c._crc32c_cffi.lib.crc32c_value(*args, **kwargs)
+def value(chunk):
+    """Compute a CRC from a chunk of data.
+
+    Args
+        chunk (Union[bytes, List[int], Tuple[int]]) new chunk of data
+
+    Returns
+        (int) New CRC computed from chunk.
+    """
+    return crc32c._crc32c_cffi.lib.crc32c_value(chunk, len(chunk))

--- a/src/crc32c/__init__.py
+++ b/src/crc32c/__init__.py
@@ -32,7 +32,7 @@ def extend(crc, chunk):
 
 
 def value(chunk):
-    """Compute a CRC from a chunk of data.
+    """Compute a CRC checksum for a chunk of data.
 
     Args
         chunk (Union[bytes, List[int], Tuple[int]]) new chunk of data

--- a/src/crc32c/__init__.py
+++ b/src/crc32c/__init__.py
@@ -39,6 +39,6 @@ def value(chunk):
             Intended to be a byte string or similar.
 
     Returns
-        (int) New CRC computed from chunk.
+        int: New CRC checksum computed for ``chunk``.
     """
     return crc32c._crc32c_cffi.lib.crc32c_value(chunk, len(chunk))

--- a/src/crc32c/__init__.py
+++ b/src/crc32c/__init__.py
@@ -21,7 +21,8 @@ def extend(crc, chunk):
 
     Args
         crc (int): An existing CRC check sum.
-        chunk (Union[bytes, List[int], Tuple[int]]) new chunk of data
+        chunk (Union[bytes, List[int], Tuple[int]]): A new chunk of data.
+            Intended to be a byte string or similar.
 
     Returns
         (int) New CRC computed by extending existing CRC with chunk.

--- a/src/crc32c/__init__.py
+++ b/src/crc32c/__init__.py
@@ -20,7 +20,7 @@ def extend(crc, chunk):
     """Update an existing CRC with new chunk of data.
 
     Args
-        crc: (int) existing CRC
+        crc (int): An existing CRC check sum.
         chunk (Union[bytes, List[int], Tuple[int]]) new chunk of data
 
     Returns

--- a/src/crc32c/__init__.py
+++ b/src/crc32c/__init__.py
@@ -25,7 +25,8 @@ def extend(crc, chunk):
             Intended to be a byte string or similar.
 
     Returns
-        (int) New CRC computed by extending existing CRC with chunk.
+        int: New CRC checksum computed by extending existing CRC
+        with ``chunk``.
     """
     return crc32c._crc32c_cffi.lib.crc32c_extend(crc, chunk, len(chunk))
 

--- a/src/crc32c/__init__.py
+++ b/src/crc32c/__init__.py
@@ -17,7 +17,7 @@ import crc32c._crc32c_cffi
 
 
 def extend(crc, chunk):
-    """Update an existing CRC with new chunk of data.
+    """Update an existing CRC checksum with new chunk of data.
 
     Args
         crc (int): An existing CRC check sum.

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -9,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import functools
 import itertools
 
 import pytest
@@ -23,6 +24,8 @@ ISCSI_SCSI_READ_10_COMMAND_PDU = [
     0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x18, 0x28, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ]
+ISCSI_LENGTH = len(ISCSI_SCSI_READ_10_COMMAND_PDU)
+ISCSI_BYTES = bytes(ISCSI_SCSI_READ_10_COMMAND_PDU)
 ISCSI_CRC = 0xd9963a56
 
 _EXPECTED = [
@@ -32,25 +35,33 @@ _EXPECTED = [
     (bytes(range(32)), 0x46dd794e),
     (bytes(reversed(range(32))), 0x113fdb5c),
     (ISCSI_SCSI_READ_10_COMMAND_PDU, ISCSI_CRC),
-    (bytes(ISCSI_SCSI_READ_10_COMMAND_PDU), ISCSI_CRC),
+    (ISCSI_BYTES, ISCSI_CRC),
 ]
 
 
 def test_extend_w_empty_chunk():
     crc = 123
-    assert crc32c.extend(crc, b'', 0) == crc
+    assert crc32c.extend(crc, b'') == crc
 
 
 def test_extend_w_multiple_chunks():
     crc = 0
-    length = len(ISCSI_SCSI_READ_10_COMMAND_PDU)
 
-    for index in itertools.islice(range(length), 0, None, 7):
+    for index in itertools.islice(range(ISCSI_LENGTH), 0, None, 7):
         chunk = ISCSI_SCSI_READ_10_COMMAND_PDU[index:index + 7]
-        crc = crc32c.extend(crc, chunk, len(chunk))
+        crc = crc32c.extend(crc, chunk)
 
     assert crc == ISCSI_CRC
 
+
+def test_extend_w_reduce():
+    chunks = (
+        ISCSI_BYTES[index:index + 3]
+        for index in itertools.islice(range(ISCSI_LENGTH), 0, None, 3)
+    )
+    assert functools.reduce(crc32c.extend, chunks, 0) == ISCSI_CRC
+
+
 @pytest.mark.parametrize("chunk, expected", _EXPECTED)
 def test_value(chunk, expected):
-    assert crc32c.value(chunk, len(chunk)) == expected
+    assert crc32c.value(chunk) == expected


### PR DESCRIPTION
- Don't require caller to pass a length to 'extend' / 'value'.
- Make arguments to 'extend' / 'value' explicit.
- Document arguments, return type for 'extend' / 'value'.
- Adjust tests accordingly.
- Add a test showing use of 'extend' with 'functools.reduce' and an iterable.